### PR TITLE
Replace sodium-native with sodium-universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "nanoassert": "^1.1.0",
-    "sodium-native": "^2.1.4"
+    "sodium-universal": "^2.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This tiny PR replaces sodium-native with sodium-universal. The test suite passes.

Thanks, Emil! This turned out to be the best documentation for the Node.js `crypto_secretstream_*` API I could find.